### PR TITLE
Add Python 3.7 and remove Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.2"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
   - "pypy3"
 
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install 'coverage<4.0.0'; fi
   - pip install coveralls
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py32,py34,py35,py36,pypy,pypy3
+envlist = py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Python 3.2 is deprecated so we remove it and add support for Python 3.7